### PR TITLE
feat: Add TCP-based LiveSplit client

### DIFF
--- a/LandfallSpeedrunningTools/LiveSplit.cs
+++ b/LandfallSpeedrunningTools/LiveSplit.cs
@@ -68,13 +68,14 @@ public class LiveSplitNamedPipe : LiveSplit
 
 public class LiveSplitTCP : LiveSplit
 {
+    private static readonly int LivesplitDefaultPort = 16834;
     private readonly TcpClient _client;
 
     public LiveSplitTCP() => _client = new TcpClient();
 
     public override async Task ConnectAsync()
     {
-        await _client.ConnectAsync("localhost", 16834);
+        await _client.ConnectAsync("localhost", LivesplitDefaultPort);
         RecvLoop(_client.GetStream());
         Debug.Log("LiveSplit client connected");
     }

--- a/LandfallSpeedrunningTools/Settings.cs
+++ b/LandfallSpeedrunningTools/Settings.cs
@@ -78,7 +78,7 @@ public class LivesplitterEnabled : EnumSetting<LivesplitterKind>, IExposedSettin
                     }
                     else if (useNamedPipe && e.GetType() == typeof(TimeoutException))
                     {
-                        message = "Make sure LiveSplit is running. If the problem persistes, restart LiveSplit, then try again.";
+                        message = "Make sure LiveSplit is running. If the problem persists, restart LiveSplit, then try again.";
                     }
                     message += "\nTo retry, go to the settings and disable, then re-enable the autosplitter.";
                     Modal.OpenModal(new DefaultHeaderModalOption("Failed to connect to LiveSplit", message), new CloseModalOnKeypress());


### PR DESCRIPTION
This PR adds a TCP client for livesplit, which is automatically used when not running on Windows, where Named Pipes are not available.

- Add a `LiveSplitTCP` implementation for the `LiveSplit` class
- Change the `LivesplitterEnabled` to a `BoolSetting`. I see the original intention of having the user choose the splitter type, but I believe "we know better than the user" anyway, I can't think of any reason to use TCP on Windows, and Named Pipes anywhere else.
- Change the "Off" string to "Disabled" for consistency with the other settings
- Log the entire exception and only show the exception message to the user
- Show some helpful tips when a known exception occurs (e.g. LiveSplit TCP server not running)

Here's a demo of running LiveSplit on Linux (laggy because I tested this on my laptop with no GPU):

https://github.com/user-attachments/assets/29fe9a06-8ab8-443b-aade-c72a8dbc3665
